### PR TITLE
💄 style : style 고도화 (사용성 관련 수정)

### DIFF
--- a/client/src/components/Map/SiteInfoCard/SiteInfoCard.js
+++ b/client/src/components/Map/SiteInfoCard/SiteInfoCard.js
@@ -54,7 +54,7 @@ const Wrapper = styled.li`
       align-items: center;
       justify-content: center;
       line-height: 16px;
-      gap: 2px;
+      gap: 4px;
       .ico-like {
         color: #ff3838;
         font-size: 16px;
@@ -66,9 +66,10 @@ const Wrapper = styled.li`
     }
 
     .more-info {
-      margin-left: 8px;
-      font-size: 16px;
-      color: #909499;
+      width: 20px;
+      margin-left: 12px;
+      font-size: 20px;
+      color: rgba(95, 105, 125, 0.7);
       :hover {
         color: #13c57c;
       }

--- a/client/src/pages/InfoModal/InfoModalStyle.js
+++ b/client/src/pages/InfoModal/InfoModalStyle.js
@@ -64,7 +64,7 @@ export const ModalWrapper = styled.div`
     padding: 18px;
     line-height: 20px;
     resize: none;
-    font-size: 1rem;
+    font-size: 0.8rem;
     box-shadow: var(--box-shadow-list);
 
     &:focus {
@@ -76,7 +76,9 @@ export const ModalWrapper = styled.div`
   }
 
   & h3 {
+    margin-bottom: 8px;
     color: #545454;
+    letter-spacing: -0.4px;
     font-weight: 500;
     height: 30px;
   }

--- a/client/src/styles/GlobalStyle.js
+++ b/client/src/styles/GlobalStyle.js
@@ -10,21 +10,12 @@ const GlobalStyle = createGlobalStyle`
     box-sizing: border-box;
   }
   html, body{
-    margin: 0;
-    padding: 0;
-    min-height: 100vh;
-    background-color: #ffffff;
-    color: #232629;
+    margin: 0; padding: 0; min-height: 100vh; background-color: #ffffff; color: #232629;
     font-family: "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
   }
 
-  a {
-    text-decoration: none;
-    outline: none;
-    font-size: 100%;
-    color: inherit;
-  }
-
+  a { text-decoration: none; outline: none; font-size: 100%; color: inherit; }
+  input { width: 90%; }
   input, button, textarea {
     font-family: Pretendard, -apple-system, system-ui, Roboto;
     background-color: transparent;

--- a/client/src/styles/GlobalStyle.js
+++ b/client/src/styles/GlobalStyle.js
@@ -9,7 +9,6 @@ const GlobalStyle = createGlobalStyle`
   * {
     box-sizing: border-box;
   }
-  
   html, body{
     margin: 0;
     padding: 0;
@@ -27,6 +26,7 @@ const GlobalStyle = createGlobalStyle`
   }
 
   input, button, textarea {
+    font-family: Pretendard, -apple-system, system-ui, Roboto;
     background-color: transparent;
     border: none;
     outline: none;


### PR DESCRIPTION
1. input 텍스트 노출 이슈 수정
2. 장소리스트카드 btn 더보기 사이즈 변경 
(기존에 유저가 클릭하기 힘든 사이즈 잡혀있어서 width와 font 20px으로 변경하였습니다.)

3. 장소상세보기 모달 font set 수정
- 모달 타이틀들 아래 영역과 물려서 margin cmm기준 8px으로 변경했습니다.
- 소개 글 기본 2줄 이상으로 작성되는 경우가 많아서 0.8rem(16px/가독성 미니멈 사이즈)으로 변경, 자간 조정했습니다.
- cmm style Font set중 textarea 누락된 것 추가했습니다. 